### PR TITLE
Add SummaryDocumentActivity creation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,3 +27,7 @@ Metrics/AbcSize:
   Exclude:
     - 'spec/features/*'
     - 'spec/requests/*'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'

--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ Or install it yourself as:
 
 ```ruby
 
-TelephoneAppointments::SummaryDocument.create(params) # returns a Summary Document
+summary_document = TelephoneAppointments::SummaryDocumentActivity.new(appointment_id: id, owner_uid: uid)
+summary_document.save # returns true or false
+
+summary_document.errors # returns a hash of errors if save is unsuccessful
 
 ```
 

--- a/lib/telephone_appointments.rb
+++ b/lib/telephone_appointments.rb
@@ -1,6 +1,9 @@
 require 'telephone_appointments/version'
 require 'telephone_appointments/api'
 
+require 'telephone_appointments/response'
+require 'telephone_appointments/summary_document_activity'
+
 require 'active_support/core_ext/module/attribute_accessors'
 
 module TelephoneAppointments
@@ -9,4 +12,6 @@ module TelephoneAppointments
   def self.api
     @api ||= TelephoneAppointments::Api.new
   end
+
+  class UnsavedObject < StandardError; end
 end

--- a/lib/telephone_appointments/api.rb
+++ b/lib/telephone_appointments/api.rb
@@ -2,11 +2,20 @@ require 'open-uri'
 
 module TelephoneAppointments
   class Api
+    def post(path, form_data)
+      uri = URI.parse("#{api_uri}#{path}")
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.read_timeout = read_timeout
+      request = Net::HTTP::Post.new(uri.request_uri, headers)
+      request.set_form_data(form_data)
+
+      Response.new(http.request(request))
+    end
+
     private
 
-    def headers_and_options
+    def headers
       {}.tap do |hash|
-        hash[:read_timeout]   = read_timeout
         hash['Authorization'] = "Bearer #{bearer_token}" if bearer_token
         hash['Accept'] = 'application/json'
       end

--- a/lib/telephone_appointments/response.rb
+++ b/lib/telephone_appointments/response.rb
@@ -1,0 +1,20 @@
+module TelephoneAppointments
+  class Response
+    def initialize(response)
+      @response = response
+    end
+
+    def success?
+      response.is_a? Net::HTTPSuccess
+    end
+
+    def errors
+      return {} if success? || response.body.nil? || response.body == ''
+      JSON.parse(response.body)
+    end
+
+    private
+
+    attr_reader :response
+  end
+end

--- a/lib/telephone_appointments/stub_api.rb
+++ b/lib/telephone_appointments/stub_api.rb
@@ -1,4 +1,7 @@
 module TelephoneAppointments
   class StubApi
+    def post(*)
+      Response.new(Net::HTTPSuccess.new(nil, nil, nil))
+    end
   end
 end

--- a/lib/telephone_appointments/summary_document_activity.rb
+++ b/lib/telephone_appointments/summary_document_activity.rb
@@ -1,0 +1,24 @@
+module TelephoneAppointments
+  class SummaryDocumentActivity
+    PATH = '/api/v1/summary_documents'.freeze
+
+    def initialize(appointment_id:, owner_uid:)
+      @appointment_id = appointment_id
+      @owner_uid = owner_uid
+    end
+
+    def save
+      @response = TelephoneAppointments.api.post(
+        PATH,
+        appointment_id: @appointment_id,
+        owner_uid: @owner_uid
+      )
+      @response.success?
+    end
+
+    def errors
+      @response || raise(TelephoneAppointments::UnsavedObject, 'Please save the object before accessing the errors')
+      @response.errors
+    end
+  end
+end

--- a/spec/cassettes/Summary_document_activity/is_successfully_created.yml
+++ b/spec/cassettes/Summary_document_activity/is_successfully_created.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:3001/api/v1/summary_documents
+    body:
+      encoding: US-ASCII
+      string: appointment_id=35&owner_uid=7827dce2-df16-4e92-ba69-39c05f27720b
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Read-Timeout:
+      - 5
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - f8b53256-bfd8-486a-acfe-dea4f77a3ac6
+      X-Runtime:
+      - '0.021276'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 18 Jan 2017 14:37:46 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/Summary_document_activity/it_lists_the_errors_when_the_create_is_unsuccessful.yml
+++ b/spec/cassettes/Summary_document_activity/it_lists_the_errors_when_the_create_is_unsuccessful.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:3001/api/v1/summary_documents
+    body:
+      encoding: US-ASCII
+      string: appointment_id&owner_uid
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 422
+      message: Unprocessable Entity
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - dafe60ff-05cd-4946-9af4-309222b3bfc1
+      X-Runtime:
+      - '0.432504'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"owner":["can''t be blank"],"appointment":["can''t be blank"]}'
+    http_version: 
+  recorded_at: Thu, 19 Jan 2017 15:29:24 GMT
+recorded_with: VCR 3.0.3

--- a/spec/features/create_a_summary_document_activity_spec.rb
+++ b/spec/features/create_a_summary_document_activity_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe 'Summary document activity', vcr: true do
+  it 'is successfully created' do
+    summary_document = TelephoneAppointments::SummaryDocumentActivity.new(
+      appointment_id: 35,
+      owner_uid: '7827dce2-df16-4e92-ba69-39c05f27720b'
+    )
+    expect(summary_document.save).to be true
+  end
+
+  it 'it lists the errors when the create is unsuccessful' do
+    summary_document = TelephoneAppointments::SummaryDocumentActivity.new(
+      appointment_id: nil,
+      owner_uid: nil
+    )
+
+    expect(summary_document.save).to be false
+    expect(summary_document.errors).to eq(
+      'appointment' => ['can\'t be blank'],
+      'owner' => ['can\'t be blank']
+    )
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'telephone_appointments'
 
+require 'pry'
 require 'vcr'
 require 'webmock/rspec'
 

--- a/spec/telephone_appointments/response_spec.rb
+++ b/spec/telephone_appointments/response_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe TelephoneAppointments::Response do
+  subject { described_class.new(response) }
+
+  context 'when the response is valid' do
+    let(:response) { Net::HTTPSuccess.new(nil, nil, nil) }
+
+    it 'is a success' do
+      expect(subject).to be_success
+    end
+
+    it 'does not have any errors' do
+      expect(subject.errors).to eq({})
+    end
+  end
+
+  context 'when the response is not valid' do
+    let(:response) { double(body: { trade: 'invalid' }.to_json) }
+
+    it 'is not a success' do
+      expect(subject).not_to be_success
+    end
+
+    it 'returns hash of errors parsed from the body text' do
+      expect(subject.errors).to eq('trade' => 'invalid')
+    end
+
+    context 'when no body is returned' do
+      let(:response) { double(body: nil) }
+
+      it 'is not a success' do
+        expect(subject).not_to be_success
+      end
+
+      it 'returns an empty error hash' do
+        expect(subject.errors).to eq({})
+      end
+    end
+  end
+end

--- a/spec/telephone_appointments/summary_document_activity_spec.rb
+++ b/spec/telephone_appointments/summary_document_activity_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+RSpec.describe TelephoneAppointments::SummaryDocumentActivity do
+  subject { described_class.new(appointment_id: 12, owner_uid: 'abc') }
+
+  describe '#errors' do
+    context 'when called before the object has been saved' do
+      it 'raises an error' do
+        expect { subject.errors }.to raise_error(
+          TelephoneAppointments::UnsavedObject,
+          'Please save the object before accessing the errors'
+        )
+      end
+    end
+
+    context 'when the object has been saved' do
+      let(:response) { double(:response, errors: [], success?: true) }
+      let(:fake_api) { double(:api, post: response) }
+
+      before do
+        allow(TelephoneAppointments.api).to receive(:post).and_return(response)
+        subject.save
+      end
+
+      it 'delegates to the response object' do
+        expect(response).to receive(:errors)
+        subject.errors
+      end
+    end
+  end
+end

--- a/telephone_appointments.gemspec
+++ b/telephone_appointments.gemspec
@@ -25,4 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'vcr'
+  spec.add_development_dependency 'webmock'
 end


### PR DESCRIPTION
Create a new TelephoneAppointment::SummaryDocumentActivity
with appointment_id and guider_uid (from signon).

Calling save on the object will post to 
`/api/v1/summary_documents`, return true is the
save was successful and false otherwise. In addition
the validation errors will be accessible via the `error`
method