### PR TITLE
Pass message value when creating SummaryDocumentActivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ Or install it yourself as:
 
 ```ruby
 
-summary_document = TelephoneAppointments::SummaryDocumentActivity.new(appointment_id: id, owner_uid: uid)
+summary_document = TelephoneAppointments::SummaryDocumentActivity.new(
+  appointment_id: id,
+  owner_uid: uid, 
+  delivery_method: message # 'postal' or 'digital'
+)
 summary_document.save # returns true or false
 
 summary_document.errors # returns a hash of errors if save is unsuccessful

--- a/lib/telephone_appointments/summary_document_activity.rb
+++ b/lib/telephone_appointments/summary_document_activity.rb
@@ -1,17 +1,24 @@
 module TelephoneAppointments
   class SummaryDocumentActivity
+    class InvalidDeliveryMethod < StandardError; end
+
+    VALID_DELIVERY_METHODS = %w(postal digital).freeze
     PATH = '/api/v1/summary_documents'.freeze
 
-    def initialize(appointment_id:, owner_uid:)
+    def initialize(appointment_id:, owner_uid:, delivery_method:)
+      raise(InvalidDeliveryMethod, delivery_method) unless VALID_DELIVERY_METHODS.include?(delivery_method)
+
       @appointment_id = appointment_id
       @owner_uid = owner_uid
+      @delivery_method = delivery_method
     end
 
     def save
       @response = TelephoneAppointments.api.post(
         PATH,
         appointment_id: @appointment_id,
-        owner_uid: @owner_uid
+        owner_uid: @owner_uid,
+        delivery_method: @delivery_method
       )
       @response.success?
     end

--- a/spec/cassettes/Summary_document_activity/is_successfully_created.yml
+++ b/spec/cassettes/Summary_document_activity/is_successfully_created.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://localhost:3001/api/v1/summary_documents
     body:
       encoding: US-ASCII
-      string: appointment_id=35&owner_uid=7827dce2-df16-4e92-ba69-39c05f27720b
+      string: appointment_id=35&owner_uid=7827dce2-df16-4e92-ba69-39c05f27720b&delivery_method=postal
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/spec/cassettes/Summary_document_activity/it_lists_the_errors_when_the_create_is_unsuccessful.yml
+++ b/spec/cassettes/Summary_document_activity/it_lists_the_errors_when_the_create_is_unsuccessful.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://localhost:3001/api/v1/summary_documents
     body:
       encoding: US-ASCII
-      string: appointment_id&owner_uid
+      string: appointment_id&owner_uid&delivery_method=postal
     headers:
       Accept:
       - application/json

--- a/spec/features/create_a_summary_document_activity_spec.rb
+++ b/spec/features/create_a_summary_document_activity_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe 'Summary document activity', vcr: true do
   it 'is successfully created' do
     summary_document = TelephoneAppointments::SummaryDocumentActivity.new(
       appointment_id: 35,
-      owner_uid: '7827dce2-df16-4e92-ba69-39c05f27720b'
+      owner_uid: '7827dce2-df16-4e92-ba69-39c05f27720b',
+      delivery_method: 'postal'
+
     )
     expect(summary_document.save).to be true
   end
@@ -12,7 +14,8 @@ RSpec.describe 'Summary document activity', vcr: true do
   it 'it lists the errors when the create is unsuccessful' do
     summary_document = TelephoneAppointments::SummaryDocumentActivity.new(
       appointment_id: nil,
-      owner_uid: nil
+      owner_uid: nil,
+      delivery_method: 'postal'
     )
 
     expect(summary_document.save).to be false

--- a/spec/telephone_appointments/summary_document_activity_spec.rb
+++ b/spec/telephone_appointments/summary_document_activity_spec.rb
@@ -1,7 +1,24 @@
 require 'spec_helper'
 
 RSpec.describe TelephoneAppointments::SummaryDocumentActivity do
-  subject { described_class.new(appointment_id: 12, owner_uid: 'abc') }
+  subject { described_class.new(appointment_id: 12, owner_uid: 'abc', delivery_method: 'postal') }
+
+  describe '.new' do
+    context 'with a valid delivery method' do
+      it 'does not raise an error' do
+        described_class.new(appointment_id: 1, owner_uid: '', delivery_method: 'postal')
+        described_class.new(appointment_id: 1, owner_uid: '', delivery_method: 'digital')
+      end
+    end
+
+    context 'with an invalid delivery method' do
+      it 'raises an error' do
+        expect do
+          described_class.new(appointment_id: nil, owner_uid: nil, delivery_method: 'other')
+        end.to raise_error(described_class::InvalidDeliveryMethod, 'other')
+      end
+    end
+  end
 
   describe '#errors' do
     context 'when called before the object has been saved' do


### PR DESCRIPTION
Add delivery_method when creating SummaryDocumentActivity

This should have a value of 'postal' or 'digital' depending
on the type of summary document that was generated.

Passing in an invalid `delivery_method` will immediately
raise an error, while passing in an invalid appointment_id 
or owner_uid will not, instead the save method will fail
and an error value will being set. 

This is due on one being a code error (delivery_method), 
while the other can be caused by the state of
the data in an external system.

ie:

* User has never logged into source system
* Appointment is in an invalid state