### PR TITLE
Create a summary document failure activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+* Create a summary document failure activity
+
 ## 0.1.0
 
 * Initial release

--- a/lib/telephone_appointments.rb
+++ b/lib/telephone_appointments.rb
@@ -3,6 +3,7 @@ require 'telephone_appointments/api'
 
 require 'telephone_appointments/response'
 require 'telephone_appointments/summary_document_activity'
+require 'telephone_appointments/dropped_summary_document_activity'
 
 require 'active_support/core_ext/module/attribute_accessors'
 

--- a/lib/telephone_appointments/api.rb
+++ b/lib/telephone_appointments/api.rb
@@ -4,13 +4,13 @@ module TelephoneAppointments
   class Api
     SSL_PORT = 443
 
-    def post(path, form_data)
+    def post(path, form_data = nil)
       uri = URI.parse("#{api_uri}#{path}")
       http = Net::HTTP.new(uri.host, uri.port)
       http.read_timeout = read_timeout
       http.use_ssl = true if uri.port == SSL_PORT
       request = Net::HTTP::Post.new(uri.request_uri, headers)
-      request.set_form_data(form_data)
+      request.set_form_data(form_data) if form_data
 
       TelephoneAppointments::Response.new(http.request(request))
     end

--- a/lib/telephone_appointments/dropped_summary_document_activity.rb
+++ b/lib/telephone_appointments/dropped_summary_document_activity.rb
@@ -1,0 +1,15 @@
+module TelephoneAppointments
+  class DroppedSummaryDocumentActivity
+    def initialize(appointment_id)
+      @appointment_id = appointment_id
+    end
+
+    def save
+      response = TelephoneAppointments.api.post(
+        "/api/v1/appointments/#{@appointment_id}/dropped_summary_documents"
+      )
+
+      response.success?
+    end
+  end
+end

--- a/lib/telephone_appointments/version.rb
+++ b/lib/telephone_appointments/version.rb
@@ -1,3 +1,3 @@
 module TelephoneAppointments
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.2.0'.freeze
 end

--- a/spec/cassettes/Create_a_failed_summary_document_delivery/is_created_successfully.yml
+++ b/spec/cassettes/Create_a_failed_summary_document_delivery/is_created_successfully.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:3001/api/v1/appointments/102176/dropped_summary_documents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-cache
+      Set-Cookie:
+      - _telephone_appointment_planner_session=WDZ4cXJEMUJGSFJQZHpRVzJuTFduQlVTZGVaRjBtaUhqamZJdmxSLzlJSGlPb0UwNFR6QldUdXVicUJPN3NHZ3RJZzJYTWovMmVHMUptYlRXUFNUVEE9PS0td3MxTGxGM3RjWkcvd1Q3bTk0YVhhQT09--283bdc466253ecd6e4f177217b16a6b1283806c3;
+        path=/; HttpOnly
+      X-Request-Id:
+      - 2039ebfd-04a1-40a7-88ec-8b7e9f09f588
+      X-Runtime:
+      - '0.089585'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 23 Feb 2017 13:27:06 GMT
+recorded_with: VCR 3.0.3

--- a/spec/features/create_a_failed_summary_document_delivery_spec.rb
+++ b/spec/features/create_a_failed_summary_document_delivery_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe 'Create a failed summary document delivery', vcr: true do
+  it 'is created successfully' do
+    activity = TelephoneAppointments::DroppedSummaryDocumentActivity.new('102176')
+
+    expect(activity.save).to be_truthy
+  end
+end

--- a/telephone_appointments.gemspec
+++ b/telephone_appointments.gemspec
@@ -6,8 +6,8 @@ require 'telephone_appointments/version'
 Gem::Specification.new do |spec|
   spec.name          = 'telephone_appointments'
   spec.version       = TelephoneAppointments::VERSION
-  spec.authors       = ['David Henry']
-  spec.email         = ['david@decoybecoy.com']
+  spec.authors       = ['Ben Lovell', 'David Henry']
+  spec.email         = ['benjamin.lovell@gmail.com', 'david@decoybecoy.com']
 
   spec.summary       = 'Pension Guidance Telephone Appointment Planner API adapter'
   spec.homepage      = 'https://github.com/guidance-guarantee-programme/telephone_appointments'


### PR DESCRIPTION
Issues a GOVUK notify based activity to alert TAP users when a summary
document email delivery has failed permanently.