### PR TITLE
Pessimistically pin development dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+* Pin development dependencies in gemspec
+
 ## 0.2.0
 
 * Create a summary document failure activity

--- a/lib/telephone_appointments/version.rb
+++ b/lib/telephone_appointments/version.rb
@@ -1,3 +1,3 @@
 module TelephoneAppointments
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.2.1'.freeze
 end

--- a/telephone_appointments.gemspec
+++ b/telephone_appointments.gemspec
@@ -20,11 +20,11 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activesupport', '>= 4', '< 5.1'
 
-  spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'pry-byebug'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rubocop'
-  spec.add_development_dependency 'vcr'
-  spec.add_development_dependency 'webmock'
+  spec.add_development_dependency 'bundler', '~> 1.14.5'
+  spec.add_development_dependency 'pry-byebug', '~> 3.4.2'
+  spec.add_development_dependency 'rake', '~> 12.0.0'
+  spec.add_development_dependency 'rspec', '~> 3.5.0'
+  spec.add_development_dependency 'rubocop', '~> 0.47.1'
+  spec.add_development_dependency 'vcr', '~> 3.0.3'
+  spec.add_development_dependency 'webmock', '~> 2.3.2'
 end


### PR DESCRIPTION
This removes several warnings at build time.