### PR TITLE
Changes for rails 5.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ AllCops:
     - 'bin/*'
     - 'db/**/*'
     - 'vendor/**/*'
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 Documentation:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
 - 2.3.3
 before_install:
 - gem update --system
-- gem install bundler -v 1.13.7
+- gem install bundler
 notifications:
   slack:
     secure: XecHmig/8T6A8kHE99V7GnXJJ6pDDH7QgjiI1gIcKXVOxsQEYDhfOgl0jZe+dn1t0rGR7JTClunI1vQCJPF/8W1iMLZHSS1oj0ow7W8Tdfo6UCKOscAsEp+5X1wxbvVEXuKwlkBQ7IcJeOeMglof6eUpOUCKm9j+NpvApXP8YYqIfBPKiMj1VQ7S/Bkckwe3DFomZxcIRKHM/TGe7A29ZauoWhXpYpy68BHMjDevmSPFXk5USigJXnBqdU/oH+uLUgBmEyc4396Yh5oQslPXxeXxavyvsIOFYIEmpjDez6JcQ7XgJy29lyZDQKYywP5yxisaXbeEpWjjqh5saaktukgRi8jLyTD2n6Zxq1udHg3TfWj+LccvF/NMu9cZGH4pvLB5jcGX5ZYlDAOddCujTsQu3mze/yb2XYSUp19bLBlA8TcnIPelAdzQS9vUGEcFfKIUvq1DQVYhsxfQ4rwyxBzbr8m4+FRum4HSDcb3HVSCCv/pusLISJS4kl+nLtk30hklRYZ/cz1CYj2WnhlsqYQOlrD/uZax0dthk+3v4cYW6tw2A3NNrEhUOUsTxH/+dPAstqmHrEKeSYJ3NTxw2Gfns2b0WB/alTFOe4S0c8/5h41G2d25wZTrUKcWyZYgdLMc9FY9CA2gvxTGKXde3UipEKwRs4GmsQ41RZsGXwg=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 rvm:
-- 2.3.3
+- 2.4.1
 before_install:
 - gem update --system
 - gem install bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.0
+
+* Loosen `activesupport` dependency to include version 5.1.x
+* Don't specify bundler in development dependencies
+
 ## 0.2.1
 
 * Pin development dependencies in gemspec

--- a/lib/telephone_appointments/version.rb
+++ b/lib/telephone_appointments/version.rb
@@ -1,3 +1,3 @@
 module TelephoneAppointments
-  VERSION = '0.2.1'.freeze
+  VERSION = '0.3.0'.freeze
 end

--- a/telephone_appointments.gemspec
+++ b/telephone_appointments.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activesupport', '>= 4', '< 5.1'
 
-  spec.add_development_dependency 'bundler', '~> 1.14.5'
   spec.add_development_dependency 'pry-byebug', '~> 3.4.2'
   spec.add_development_dependency 'rake', '~> 12.0.0'
   spec.add_development_dependency 'rspec', '~> 3.5.0'

--- a/telephone_appointments.gemspec
+++ b/telephone_appointments.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activesupport', '>= 4', '< 5.1'
+  spec.add_runtime_dependency 'activesupport', '>= 4', '< 5.2'
 
   spec.add_development_dependency 'pry-byebug', '~> 3.4.2'
   spec.add_development_dependency 'rake', '~> 12.0.0'


### PR DESCRIPTION
Mainly just expanded the `activesupport` dependency version constraint.

Also updated `travis.yml` to target 2.4.1 as I think we're up to that most everywhere and removed the emphasis on a specific version of bundler.